### PR TITLE
Write optimal moran player experiments (#69)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,8 +3,10 @@ channels:
   - defaults
 dependencies:
   - python=3.6.7
+  - matplotlib=3.2.2
   - numpy=1.15.4
   - pandas=0.23.4
+  - scikit-learn=0.20.1
   - pip:
     - attrs==19.1.0
     - axelrod==4.4.0

--- a/moran_data/moran/README.md
+++ b/moran_data/moran/README.md
@@ -1,0 +1,97 @@
+Data collection for the Moran process.
+
+Running `main.py` will generate (or append to) `main.csv` with calculations
+for the Moran process (with N=4) with an optimal memory 1 player that updates
+at every generation.
+
+To run:
+
+```
+$ python main.py
+```
+
+The data set is of the form:
+
+```
+Seed, Opponent p1, Opponent p2, Opponent p3, Opponent p4, K, Best response p1, Best response p2, Best response p3, Best respose p4, A_11, A_12, A_21, A_22, x_k, non_dynamic_x_k
+```
+
+Approach:
+
+The fixation probability \\(x_k\\) is given by:
+
+\\[
+    x_k = \frac{
+            1 + \sum_{j=1}^{k-1}\prod_{i=1}^j\gamma_i
+                }{
+            1 + \sum_{j=1}^{N-1}\prod_{i=1}^j\gamma_i
+                }
+\\]
+
+where:
+
+\\[
+    \gamma_i = \frac{
+                 p_{k, k - 1}
+                    }{
+                 p_{k, k + 1}
+                    }
+\\]
+
+Where \\(k\\) is the number of best response players in the population, so that
+\\(N - k\\) is the number of opponents.
+
+Note that for every value of \\(k\\) there is a different best response player.
+
+In the case of the best response player the transition probabilities depend on
+the payoff matrix \\(A ^ {(k)}\\) where:
+
+- \\(A ^ {(k)}\_{11}\\) is the utility of the best response player against
+  itself.
+- \\(A ^ {(k)}\_{12}\\) is the utility of the best response player against
+  the opponent.
+- \\(A ^ {(k)}\_{11}\\) is the utility of the opponent against
+  the best response player.
+- \\(A ^ {(k)}\_{11}\\) is the utility of the opponent against itself.
+
+The matrix \\(A ^ {(k)}\\) is calculated for each value of \\(k\\) once the best
+response dynamics algorithm has calculated the best response player.
+
+Using this we can write down the total utilities/fitnesses for each player:
+
+\\[f_1^{(k)} = (k - 1) A_{11}^{(k)} + (N - k)A_{12}^{(k)}\\]
+
+\\[f_2^{(k)} = (k) A_{21}^{(k)} + (N - k - 1)A_{22}^{(k)}\\]
+
+(\\(f_1^{(k)}\\) is the fitness of the best response player, and \\(f_2^{(k)}\\)
+is the fitness of the opponent)
+
+Using this we have:
+
+\\[
+    p_{k, k - 1} = \frac{
+                     (N - k)f_2^{(k)}
+                    }{
+                     kf_1^{(k)}+(N - k)f_2^{(k)}
+                    }
+                    \frac{
+                     k
+                    }{
+                     N
+                    }
+\\]
+
+and:
+
+\\[
+    p_{k, k + 1} = \frac{
+                     kf_1^{(k)}
+                    }{
+                     kf_1^{(k)}+(N - k)f_2^{(k)}
+                    }
+                    \frac{
+                     (N - k)
+                    }{
+                     N
+                    }
+\\]

--- a/moran_data/moran/main.py
+++ b/moran_data/moran/main.py
@@ -1,0 +1,152 @@
+import csv
+
+import axelrod as axl
+import numpy as np
+import pandas as pd
+
+import opt_mo
+
+
+def theoretic_fixation(N, payoff_matrix, K=1):
+    """
+    Calculate x_i assuming a non dynamic player
+    """
+    f_ones = np.array(
+        [
+            (payoff_matrix[0, 0] * (K - 1) + payoff_matrix[0, 1] * (N - K))
+            for K in range(1, N)
+        ]
+    )
+    f_twos = np.array(
+        [
+            (payoff_matrix[1, 0] * K + payoff_matrix[1, 1] * (N - K - 1))
+            for K in range(1, N)
+        ]
+    )
+    gammas = f_twos / f_ones
+    return (1 + np.sum(np.cumprod(gammas[: K - 1]))) / (
+        1 + np.sum(np.cumprod(gammas))
+    )
+
+
+def obtain_payoff_matrix(opponent, K, N=4):
+    """
+    Obtain the payoff matrix for K best response players in a population of a
+    total of N individuals.
+    """
+    best_ev_response, _, _ = opt_mo.get_evolutionary_best_response(
+        [opponent] * (N - K), opt_mo.get_memory_one_best_response, K=K
+    )
+    players = [best_ev_response, opponent]
+    return (
+        np.array(
+            [
+                [opt_mo.match_utility(player, opponent) for opponent in players]
+                for player in players
+            ]
+        ),
+        best_ev_response,
+    )
+
+
+def best_response_moran_process(opponent, N=4):
+    payoff_matrices = {}
+    best_response_players = {}
+    for K in range(1, N):
+        payoff_matrix, best_response = obtain_payoff_matrix(
+            opponent=opponent, K=K
+        )
+        payoff_matrices[K] = payoff_matrix
+        best_response_players[K] = best_response
+
+    f_ones = np.array(
+        [
+            (
+                payoff_matrices[K][0, 0] * (K - 1)
+                + payoff_matrices[K][0, 1] * (N - K)
+            )
+            for K in range(1, N)
+        ]
+    )
+    f_twos = np.array(
+        [
+            (
+                payoff_matrices[K][1, 0] * K
+                + payoff_matrices[K][1, 1] * (N - K - 1)
+            )
+            for K in range(1, N)
+        ]
+    )
+    gammas = f_twos / f_ones
+    return (
+        {
+            K: (1 + np.sum(np.cumprod(gammas[: K - 1])))
+            / (1 + np.sum(np.cumprod(gammas)))
+            for K in range(1, N)
+        },
+        payoff_matrices,
+        best_response_players,
+    )
+
+
+if __name__ == "__main__":
+    N = 4
+    try:
+        df = pd.read_csv("data.csv")
+        try:
+            seed = int(df["seed"].max())
+        except ValueError:
+            seed = 0
+    except FileNotFoundError:
+        header = [
+            "seed",
+            "Opponent_p1",
+            "Opponent_p2",
+            "Opponent_p3",
+            "Opponent_p4",
+            "K",
+            "Best_response_p1",
+            "Best_response_p2",
+            "Best_response_p3",
+            "Best_response_p4",
+            "A_11",
+            "A_12",
+            "A_21",
+            "A_22",
+            "x_K",
+            "non_dynamic_x_K",
+        ]
+        seed = 0
+        with open("data.csv", "w") as f:
+            csv_writer = csv.writer(f)
+            csv_writer.writerow(header)
+
+    while True:
+        with open("data.csv", "a") as f:
+            csv_writer = csv.writer(f)
+
+            np.random.seed(seed)
+            opponent = np.random.random(4)
+            (
+                fixation_probabilities,
+                payoff_matrices,
+                best_response_players,
+            ) = best_response_moran_process(opponent, N=N)
+
+            row = [seed] + list(opponent)
+            for K in range(1, N):
+                payoff_matrix = list(payoff_matrices[K].flatten())
+                best_response = list(best_response_players[K])
+                x_K = fixation_probabilities[K]
+                non_dynamic_x_K = theoretic_fixation(
+                    payoff_matrix=payoff_matrices[K], N=N, K=K
+                )
+                csv_writer.writerow(
+                    row
+                    + [K]
+                    + payoff_matrix
+                    + best_response
+                    + [x_K, non_dynamic_x_K]
+                )
+
+            seed += 1

--- a/src/opt_mo/__init__.py
+++ b/src/opt_mo/__init__.py
@@ -1,6 +1,6 @@
 from .evolutionary_best_response import (
     get_evolutionary_best_response,
-    get_repeat_length_in_history,
+    get_repeat_cycle_and_length,
 )
 from .gambler_best_response import (
     get_best_response_gambler,

--- a/src/opt_mo/evolutionary_best_response.py
+++ b/src/opt_mo/evolutionary_best_response.py
@@ -1,7 +1,8 @@
 import numpy as np
+import opt_mo
 
 
-def get_repeat_length_in_history(history, tol=10 ** -5):
+def get_repeat_cycle_and_length(history, tol=10 ** -5):
     """
     Find any repeat of last moves in history. Including repeats of just one element 
     (so this can be used to check simple convergence as well as "cyclic convergence").
@@ -18,8 +19,8 @@ def get_repeat_length_in_history(history, tol=10 ** -5):
             history[-2 * cycle_size : -cycle_size],
             atol=tol,
         ):
-            return len(history[-cycle_size:])
-    return float("inf")
+            return history[-cycle_size:], len(history[-cycle_size:])
+    return None, float("inf")
 
 
 def get_evolutionary_best_response(
@@ -27,18 +28,32 @@ def get_evolutionary_best_response(
     best_response_function,
     tol=10 ** -5,
     initial=np.array([1, 1, 1, 1]),
+    K=1,
 ):
+    """
+    This implements the best response dynamics algorithm (Algorithm 1) in the
+    manuscript.
+
+    Given a set of opponents it repeatedly finds the best response to the
+    opponents including a `K` self interactions.
+    """
 
     history = [initial]
-    best_response = best_response_function(opponents + history)
+    best_response = best_response_function(opponents + history * K)
     history.append(best_response)
 
-    repeat_length = get_repeat_length_in_history(history, tol=tol)
+    _, repeat_length = get_repeat_cycle_and_length(history, tol=tol)
     while repeat_length >= float("inf"):
 
-        best_response = best_response_function(opponents + [history[-1]])
+        best_response = best_response_function(opponents + [history[-1]] * K)
         print("Next generation.")
         history.append(best_response)
-        repeat_length = get_repeat_length_in_history(history, tol=tol)
+        cycle, repeat_length = get_repeat_cycle_and_length(history, tol=tol)
 
+    utilities = [
+        opt_mo.tournament_utility(player, opponents + [player] * K)
+        for player in cycle
+    ]
+
+    best_response = cycle[utilities.index(np.nanmax(utilities))]
     return best_response, history, repeat_length

--- a/src/opt_mo/utility.py
+++ b/src/opt_mo/utility.py
@@ -258,7 +258,6 @@ def tournament_utility(player, opponents):
     The tournament utility of a player is the sum of utilities against each
     opponent and against itself.
     """
-    obj = 0
     return np.mean([match_utility(player, opponent) for opponent in opponents])
 
 

--- a/tests/test_evolutionary_best_response.py
+++ b/tests/test_evolutionary_best_response.py
@@ -6,7 +6,7 @@ import numpy as np
 import opt_mo
 
 
-def test_get_repeat_length_in_history_with_single_element():
+def test_get_repeat_cycle_and_length_with_single_element():
     history_with_single_element_cycle = (
         np.array([0.3, 0.4, 0.3, 0.3]),
         np.array([0.3, 0.7, 0.3, 0.8]),
@@ -14,13 +14,19 @@ def test_get_repeat_length_in_history_with_single_element():
         np.array([0.3, 0.4, 0.3, 0.3]),
     )
 
-    assert (
-        opt_mo.get_repeat_length_in_history(history_with_single_element_cycle)
-        == 1
+    cycle, cycle_length = opt_mo.get_repeat_cycle_and_length(
+        history_with_single_element_cycle
     )
 
+    assert cycle_length == 1
 
-def test_get_repeat_length_in_history_with_two_elements():
+    for history, expected_history in zip(
+        cycle, (np.array([0.3, 0.4, 0.3, 0.3]),)
+    ):
+        assert (history == expected_history).all()
+
+
+def test_get_repeat_cycle_and_length_with_two_elements():
     history_with_two_element_cycle = (
         np.array([0.3, 0.4, 0.3, 0.3]),
         np.array([0.3, 0.7, 0.3, 0.8]),
@@ -30,12 +36,18 @@ def test_get_repeat_length_in_history_with_two_elements():
         np.array([0.3, 0.4, 0.3, 0.4]),
     )
 
-    assert (
-        opt_mo.get_repeat_length_in_history(history_with_two_element_cycle) == 2
+    cycle, cycle_length = opt_mo.get_repeat_cycle_and_length(
+        history_with_two_element_cycle
     )
+    assert cycle_length == 2
+
+    for history, expected_history in zip(
+        cycle, (np.array([0.3, 0.4, 0.3, 0.3]), np.array([0.3, 0.4, 0.3, 0.4]))
+    ):
+        assert (history == expected_history).all()
 
 
-def test_get_repeat_length_in_history_with_three_elements():
+def test_get_repeat_cycle_and_length_with_three_elements():
     history_with_three_element_cycle = (
         np.array([0.3, 0.4, 0.3, 0.3]),
         np.array([0.3, 0.7, 0.3, 0.8]),
@@ -49,13 +61,24 @@ def test_get_repeat_length_in_history_with_three_elements():
         np.array([0.3, 0.4, 0.2, 0.4]),
     )
 
-    assert (
-        opt_mo.get_repeat_length_in_history(history_with_three_element_cycle)
-        == 3
+    cycle, cycle_length = opt_mo.get_repeat_cycle_and_length(
+        history_with_three_element_cycle
     )
+    assert cycle_length == 3
+
+    for history, expected_history in zip(
+        cycle,
+        (
+            np.array([0.7, 0.4, 0.3, 0.3]),
+            np.array([0.3, 0.4, 0.3, 0.4]),
+            np.array([0.3, 0.4, 0.2, 0.4]),
+        ),
+    ):
+
+        assert (history == expected_history).all()
 
 
-def test_get_repeat_length_in_history_with_three_elements_and_floating_error():
+def test_get_repeat_cycle_and_length_with_three_elements_and_floating_error():
     history_with_three_element_cycle_and_floating_point_error = (
         np.array([0.3, 0.4, 0.3, 0.3]),
         np.array([0.3, 0.7, 0.3, 0.8]),
@@ -69,15 +92,13 @@ def test_get_repeat_length_in_history_with_three_elements_and_floating_error():
         np.array([0.3, 0.4, 0.2, 0.4]),
     )
 
-    assert (
-        opt_mo.get_repeat_length_in_history(
-            history_with_three_element_cycle_and_floating_point_error
-        )
-        == 3
+    _, cycle_length = opt_mo.get_repeat_cycle_and_length(
+        history_with_three_element_cycle_and_floating_point_error
     )
+    assert cycle_length == 3
 
 
-def test_get_repeat_length_in_history_no_cycle():
+def test_get_repeat_cycle_and_length_no_cycle():
     history_with_no_cycle = (
         np.array([0.3, 0.4, 0.3, 0.3]),
         np.array([0.3, 0.7, 0.3, 0.8]),
@@ -90,12 +111,16 @@ def test_get_repeat_length_in_history_no_cycle():
         np.array([0.3, 0.4, 0.3, 0.4]),
     )
 
-    assert opt_mo.get_repeat_length_in_history(history_with_no_cycle) == float(
-        "inf"
+    cycle, cycle_length = opt_mo.get_repeat_cycle_and_length(
+        history_with_no_cycle
     )
 
+    assert cycle == None
 
-def test_get_repeat_length_in_history_from_the_beginning():
+    assert cycle_length == float("inf")
+
+
+def test_get_repeat_cycle_and_length_from_the_beginning():
     history_with_cycle_from_the_beginning = (
         np.array([0.3, 0.4, 0.3, 0.3]),
         np.array([0.3, 0.7, 0.3, 0.8]),
@@ -103,21 +128,124 @@ def test_get_repeat_length_in_history_from_the_beginning():
         np.array([0.3, 0.7, 0.3, 0.8]),
     )
 
-    assert (
-        opt_mo.get_repeat_length_in_history(
-            history_with_cycle_from_the_beginning
-        )
-        == 2
+    cycle, cycle_length = opt_mo.get_repeat_cycle_and_length(
+        history_with_cycle_from_the_beginning
     )
 
+    assert cycle_length == 2
 
-def test_get_evolutionary_best_response():
+    for history, expected_history in zip(
+        cycle, (np.array([0.3, 0.4, 0.3, 0.3]), np.array([0.3, 0.7, 0.3, 0.8]))
+    ):
+
+        assert (history == expected_history).all()
+
+
+def test_get_evolutionary_best_response_against_random_opponent():
     axl.seed(2)
-    random_opponents = [[random.random() for _ in range(4)] for _ in range(1)]
+    random_opponents = [[random.random() for _ in range(4)]]
 
-    best_ev_response, hist, history_length = opt_mo.get_evolutionary_best_response(
+    (
+        best_ev_response,
+        hist,
+        history_length,
+    ) = opt_mo.get_evolutionary_best_response(
         random_opponents, opt_mo.get_memory_one_best_response
     )
 
+    expected_best_response = np.array([0.0, 0.0, 0.0, 0.0])
+    assert type(best_ev_response) is np.ndarray
+    assert np.allclose(expected_best_response, best_ev_response)
+
+
+def test_get_evolutionary_best_response_with_K_equal_2_against_random_opponent():
+    axl.seed(2)
+    random_opponents = [[random.random() for _ in range(4)]]
+
+    (
+        best_ev_response,
+        hist,
+        history_length,
+    ) = opt_mo.get_evolutionary_best_response(
+        random_opponents, opt_mo.get_memory_one_best_response, K=2
+    )
+
+    expected_best_response = np.array([0.11235944, 0, 0, 0])
     assert type(best_ev_response) is np.ndarray
     assert len(best_ev_response) == 4
+    assert np.allclose(expected_best_response, best_ev_response)
+
+
+def test_get_evolutionary_best_response_with_K_equal_4_against_random_opponent():
+    axl.seed(2)
+    random_opponents = [[random.random() for _ in range(4)]]
+
+    (
+        best_ev_response,
+        hist,
+        history_length,
+    ) = opt_mo.get_evolutionary_best_response(
+        random_opponents, opt_mo.get_memory_one_best_response, K=4
+    )
+
+    expected_best_response = np.array([0.01547687, 0, 0, 0])
+    assert type(best_ev_response) is np.ndarray
+    assert len(best_ev_response) == 4
+    assert np.allclose(expected_best_response, best_ev_response, atol=1e-3)
+
+
+def test_get_evolutionary_best_response_with_K_equal_1_against_2_defectors():
+    """
+    We see that the expected best response against 2 defectors is:
+
+    [1, 0.45420466, 0, 0.03799109]
+
+    - the first term: indicates that when the player is playing against itself
+      it knows to always cooperate.
+    - The second term (P_CD): it will still cooperate with relatively high
+      probability (0.454...).
+    - The third term (P_DC): it will never cooperate after defecting against one
+      a player like itself.
+    - The final term (P_DD): it is very likely to defect on the occasions where
+      it defected and so did it's opponent (probably likely that the opponent is
+      defector?).
+    """
+    opponents = [np.array([0, 0, 0, 0])] * 2
+
+    axl.seed(2)
+    (
+        best_ev_response,
+        hist,
+        history_length,
+    ) = opt_mo.get_evolutionary_best_response(
+        opponents, opt_mo.get_memory_one_best_response, K=1
+    )
+
+    expected_best_response = np.array([1, 0.45420466, 0, 0.03799109])
+    assert type(best_ev_response) is np.ndarray
+    assert len(best_ev_response) == 4
+    assert np.allclose(expected_best_response, best_ev_response)
+
+
+def test_get_evolutionary_best_response_with_K_equal_10_against_2_defectors():
+    """
+    With K = 10 and 2 defectors the best response changes from `[1, 0.45420466,
+    0, 0.03799109]` (for K = 1) to:
+
+    [1, 0.36819048, 1, 0.75011483]
+    """
+    opponents = [np.array([0, 0, 0, 0])] * 2
+
+    axl.seed(2)
+    (
+        best_ev_response,
+        hist,
+        history_length,
+    ) = opt_mo.get_evolutionary_best_response(
+        opponents, opt_mo.get_memory_one_best_response, K=10
+    )
+
+    expected_best_response = np.array([1, 0.36819048, 1, 0.75011483])
+    assert type(best_ev_response) is np.ndarray
+    assert len(best_ev_response) == 4
+    assert np.allclose(expected_best_response, best_ev_response, atol=1e-3)


### PR DESCRIPTION
* Adjust the environment due to upstream updates

Tests would not run on my machine due to some upstream change in:

- `matplotlib`, error messages lead me to:
  https://stackoverflow.com/questions/31373163/anaconda-runtime-error-python-is-not-installed-as-a-framework/41433353
- `sklearn` (a dependency of `scikit-opt`), error messages lead me to:
  https://github.com/skggm/skggm/issues/124

* Write tests for ability for K self interactions

* Implement ability to have K self interactions

@Nikoleta-V3 could you take a close look at the tests please. I'm not
entirely sure the behaviour makes sense to me (I would expect that as K
increases the optimal behaviour would be to in general cooperate
more...).

* Add data structure for data collection.

Looks like `data/` is in `.gitignore` so I've called this `moran_data`
for now but we should find a better data structure.

Also: I'm writing to `csv` it would be nicer to write to an sql
database.

* Rewrite README to use analytical approach.

* Remove unnecessary line.

* Add computation of non dynamic fixation.

* Write script to carry out Moran process.

* Reduce absolute tolerance for two numeric tests.

* Run black.

* Run black again.

* Apply suggestions from code review with Nik

* rename function and also return cycle

renames get_repeat_length_in_history to get_repeat_cycle_and_length

* uncomment tests

* return the strategy with the highest score in case of a cycle

the tests are currently failing (correctly)

* pass tests

* Fix typos in README

* Update src/opt_mo/evolutionary_best_response.py

Co-authored-by: Vince Knight <vincent.knight@gmail.com>

Co-authored-by: Nikoleta Glynatsi <glynatsine@cardiff.ac.uk>